### PR TITLE
Implement a method to prevent Spectre-SSB

### DIFF
--- a/Processor/Src/Cache/DCache.sv
+++ b/Processor/Src/Cache/DCache.sv
@@ -1160,6 +1160,14 @@ module DCache(
 
         for (int i = 0; i < DCACHE_LSU_PORT_NUM; i++) begin
             mshrConflict[i] = port.lsuMuxTagOut[i].mshrConflict;
+
+            // For preventing Spectre-SSB
+            // Lock allocating MSHR by triggering mshrConflict
+            if (i < DCACHE_LSU_READ_PORT_NUM) begin
+                if (lsu.lockAllocatingMSHR[i]) begin
+                    mshrConflict[i] = TRUE;
+                end
+            end
         end
 
         // Check address conflict in missed access in this cycle.

--- a/Processor/Src/LoadStoreUnit/LoadStoreUnitIF.sv
+++ b/Processor/Src/LoadStoreUnit/LoadStoreUnitIF.sv
@@ -129,6 +129,10 @@ interface LoadStoreUnitIF( input logic clk, rst, rstStart );
     logic conflict [ STORE_ISSUE_WIDTH ];
     logic memAccessOrderViolation [ STORE_ISSUE_WIDTH ];
     PC_Path conflictLoadPC [ STORE_ISSUE_WIDTH ];
+
+    // Added for preventing Spectre-SSB
+    // logic existUnknownStoreAddr[LOAD_ISSUE_WIDTH];
+    logic lockAllocatingMSHR[LOAD_ISSUE_WIDTH];
     
     modport DCache(
     input
@@ -145,6 +149,7 @@ interface LoadStoreUnitIF( input logic clk, rst, rstStart );
         dcReadUncachable,
         dcReadActiveListPtr,
         makeMSHRCanBeInvalidDirect,
+        lockAllocatingMSHR,
     output
         dcReadHit,
         dcReadBusy,
@@ -224,7 +229,8 @@ interface LoadStoreUnitIF( input logic clk, rst, rstStart );
         retiredStoreLSQ_BlockAddr,
         storeQueueEmpty,
         storeQueueCount,
-        storeQueueHeadPtr
+        storeQueueHeadPtr,
+        lockAllocatingMSHR
     );
 
     modport StoreCommitter(

--- a/Processor/Src/LoadStoreUnit/LoadStoreUnitIF.sv
+++ b/Processor/Src/LoadStoreUnit/LoadStoreUnitIF.sv
@@ -354,7 +354,8 @@ interface LoadStoreUnitIF( input logic clk, rst, rstStart );
     modport ReplayQueue(
     input
         mshrValid,
-        mshrPhase
+        mshrPhase,
+        lockAllocatingMSHR
     );
 
     modport CommitStage(

--- a/Processor/Src/LoadStoreUnit/LoadStoreUnitTypes.sv
+++ b/Processor/Src/LoadStoreUnit/LoadStoreUnitTypes.sv
@@ -193,7 +193,10 @@ typedef struct packed // StoreQueueDataEntry
     LSQ_WordByteEnablePath byteWE;
 } StoreQueueDataEntry;
 
-localparam ENABLE_PREVENTING_SSB = FALSE;
+localparam ENABLE_PREVENTING_SSB = TRUE;
+localparam LOCK_CYCLES_TO_REPLAY = 5;
+localparam LOCK_CYCLES_TO_REPLAY_BIT_WIDTH = LOCK_CYCLES_TO_REPLAY > 0 ? $clog2(LOCK_CYCLES_TO_REPLAY) : 1;
+typedef logic [LOCK_CYCLES_TO_REPLAY_BIT_WIDTH-1:0] LockCyclesToReplayPath;
 
 
 endpackage

--- a/Processor/Src/LoadStoreUnit/LoadStoreUnitTypes.sv
+++ b/Processor/Src/LoadStoreUnit/LoadStoreUnitTypes.sv
@@ -193,6 +193,8 @@ typedef struct packed // StoreQueueDataEntry
     LSQ_WordByteEnablePath byteWE;
 } StoreQueueDataEntry;
 
+localparam ENABLE_PREVENTING_SSB = FALSE;
+
 
 endpackage
 

--- a/Processor/Src/LoadStoreUnit/StoreQueue.sv
+++ b/Processor/Src/LoadStoreUnit/StoreQueue.sv
@@ -321,7 +321,8 @@ module StoreQueue(
             end
 
             // Block allocating MSHR while there is a store with an unknown address
-            lockAllocatingMSHR[i] = port.executeLoad[i] && existUnknownStoreAddr[i];
+            lockAllocatingMSHR[i] = ENABLE_PREVENTING_SSB ? 
+                port.executeLoad[i] && existUnknownStoreAddr[i] : FALSE;
         end
 
         for (int i = 0; i < LOAD_ISSUE_WIDTH; i++) begin


### PR DESCRIPTION
This PR includes following modification:
Implemented a mechanism to lock allocating MSHR while a prior store with an unknown address.